### PR TITLE
PermissionGrant: Introduce Support for flashing Gapps

### DIFF
--- a/services/core/java/com/android/server/pm/DefaultPermissionGrantPolicy.java
+++ b/services/core/java/com/android/server/pm/DefaultPermissionGrantPolicy.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 The Android Open Source Project
+ * Copyright (C) 2015 Alex Naidis <alex.naidis@linux.com> , Team Exodus, The Linux Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -608,6 +609,55 @@ final class DefaultPermissionGrantPolicy {
                 grantRuntimePermissionsLPw(gmscorePackage, STORAGE_PERMISSIONS, userId);
             }
 
+			// Google Connectivity Services
+            PackageParser.Package gcsPackage = getDefaultProviderAuthorityPackageLPr(
+                    "com.google.android.apps.gcs", userId);
+            if (gcsPackage != null) {
+                grantRuntimePermissionsLPw(gcsPackage, CONTACTS_PERMISSIONS, userId);
+                grantRuntimePermissionsLPw(gcsPackage, LOCATION_PERMISSIONS, userId);
+            }
+
+			// Google Contacts Sync
+            PackageParser.Package googlecontactssyncPackage = getDefaultProviderAuthorityPackageLPr(
+                    "com.google.android.syncadapters.contacts", userId);
+            if (googlecontactssyncPackage != null) {
+                grantRuntimePermissionsLPw(googlecontactssyncPackage, CONTACTS_PERMISSIONS, userId);
+            }			
+
+			// Google Backup Transport
+            PackageParser.Package googlebackuptransportPackage = getDefaultProviderAuthorityPackageLPr(
+                    "com.google.android.backuptransport", userId);
+            if (googlebackuptransportPackage != null) {
+                grantRuntimePermissionsLPw(googlebackuptransportPackage, CONTACTS_PERMISSIONS, userId);
+            }			
+			
+			// Google Play Framework
+            PackageParser.Package gsfcorePackage = getDefaultProviderAuthorityPackageLPr(
+                    "com.google.android.gsf", userId);
+            if (gsfcorePackage != null) {
+                grantRuntimePermissionsLPw(gsfcorePackage, CONTACTS_PERMISSIONS, userId);
+                grantRuntimePermissionsLPw(gsfcorePackage, PHONE_PERMISSIONS, userId);
+            }		
+
+			// Google Setup Wizard
+            PackageParser.Package setupwizardPackage = getDefaultProviderAuthorityPackageLPr(
+                    "com.google.android.setupwizard", userId);
+            if (setupwizardPackage != null) {
+                grantRuntimePermissionsLPw(setupwizardPackage, CONTACTS_PERMISSIONS, userId);
+                grantRuntimePermissionsLPw(setupwizardPackage, PHONE_PERMISSIONS, userId);
+            }	
+
+			// Google Play Store
+            PackageParser.Package vendingPackage = getDefaultProviderAuthorityPackageLPr(
+                    "com.android.vending", userId);
+            if (vendingPackage != null) {
+                grantRuntimePermissionsLPw(vendingPackage, CONTACTS_PERMISSIONS, userId);
+                grantRuntimePermissionsLPw(vendingPackage, PHONE_PERMISSIONS, userId);
+                grantRuntimePermissionsLPw(vendingPackage, LOCATION_PERMISSIONS, userId);
+                grantRuntimePermissionsLPw(vendingPackage, SMS_PERMISSIONS, userId);
+            }	
+				
+			
             mService.mSettings.onDefaultRuntimePermissionsGrantedLPr(userId);
         }
     }


### PR DESCRIPTION
- this makes AOSP/CAF based ROMs compatible with 6.0 Gapps packages
- this resolves the problem of permissions not being granted to google core apps
- this will probably need to be updated regulary
- this resolves one aspect of opengapps/opengapps#93

Copyright (C) by Alex Naidis (alex.naidis@linux.com), Team Exodus, The Linux Foundation

Change-Id: Iee4954d0425d8040361ff0fba653c5f1583f3bf2
Signed-off-by: Alex Naidis alex.naidis@linux.com
